### PR TITLE
CRAN Check Failure for Upcoming broom Release

### DIFF
--- a/R/impact_eval.R
+++ b/R/impact_eval.R
@@ -102,7 +102,8 @@ impact_eval <- function(data, endogenous_vars, treatment,
   ITT_het<-purrr::map2(heterogenous_vars_final, formulas_het,
                           function(x, y) data %>%
                             dplyr::group_by(!!rlang::sym(x)) %>% dplyr::do(fit = lfe::felm(stats::as.formula(y),
-                                                                      data = .)) %>% broom::tidy(., fit) )
+                                                                      data = .)) ) %>%
+    purrr::map(., function(x) purrr::map_dfr(x$fit, broom::tidy))
 
   base::names(ITT_het)<-stringr::str_c(endogenous_vars_final, heterogenous_vars_final, sep = "_")
 

--- a/tests/testthat/test_impact_eval.R
+++ b/tests/testthat/test_impact_eval.R
@@ -72,7 +72,7 @@ test_that("impact_eval correct dimensions tests", {
   expect_equal(length(imp_eval3), 2)
   expect_equal(ncol(imp_eval3$log_outcome), 5)
   expect_equal(nrow(imp_eval3$log_outcome), 4)
-  expect_equal(ncol(imp_eval3$log_outcome_inc_quartile), 6)
+  expect_equal(ncol(imp_eval3$log_outcome_inc_quartile), 5)
   expect_equal(nrow(imp_eval3$log_outcome_inc_quartile), 16)
   
   


### PR DESCRIPTION
Hi there! The broom dev team just ran reverse dependency checks on the upcoming broom 0.7.0 release and found new errors/test failures for the CRAN version of this package. The failures are related to the deprecation of rowwise dataframe tidiers—I've written alternative code that uses the the `tidy.felm` method multiple times explicitly instead of having `tidy.rowwise_df` take care of handling the methods / row-binding.

We hope to submit this new version of the package to CRAN in the coming weeks. Hopeful that this fix is helpful for you in the meantime! :-)